### PR TITLE
make auth consistent for ton center apis

### DIFF
--- a/ecosystem/rpc/ton-center-http-api-v-2.json
+++ b/ecosystem/rpc/ton-center-http-api-v-2.json
@@ -1730,14 +1730,7 @@
             "description": "Lite Server Timeout"
           }
         },
-        "security": [
-          {
-            "APIKeyHeader": []
-          },
-          {
-            "APIKeyQuery": []
-          }
-        ]
+        "security": []
       }
     },
     "/getOutMsgQueueSizes": {
@@ -2137,14 +2130,7 @@
             "description": "Lite Server Timeout"
           }
         },
-        "security": [
-          {
-            "APIKeyHeader": []
-          },
-          {
-            "APIKeyQuery": []
-          }
-        ]
+        "security": []
       }
     },
     "/sendBocReturnHash": {
@@ -2183,14 +2169,7 @@
             "description": "Lite Server Timeout"
           }
         },
-        "security": [
-          {
-            "APIKeyHeader": []
-          },
-          {
-            "APIKeyQuery": []
-          }
-        ]
+        "security": []
       }
     },
     "/sendQuery": {
@@ -2229,14 +2208,7 @@
             "description": "Lite Server Timeout"
           }
         },
-        "security": [
-          {
-            "APIKeyHeader": []
-          },
-          {
-            "APIKeyQuery": []
-          }
-        ]
+        "security": []
       }
     },
     "/estimateFee": {
@@ -2275,14 +2247,7 @@
             "description": "Lite Server Timeout"
           }
         },
-        "security": [
-          {
-            "APIKeyHeader": []
-          },
-          {
-            "APIKeyQuery": []
-          }
-        ]
+        "security": []
       }
     },
     "/runGetMethod": {
@@ -2321,14 +2286,7 @@
             "description": "Lite Server Timeout"
           }
         },
-        "security": [
-          {
-            "APIKeyHeader": []
-          },
-          {
-            "APIKeyQuery": []
-          }
-        ]
+        "security": []
       }
     },
     "/jsonRPC": {
@@ -2367,30 +2325,11 @@
             "description": "Lite Server Timeout"
           }
         },
-        "security": [
-          {
-            "APIKeyHeader": []
-          },
-          {
-            "APIKeyQuery": []
-          }
-        ]
+        "security": []
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "APIKeyHeader": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-Key"
-      },
-      "APIKeyQuery": {
-        "type": "apiKey",
-        "in": "query",
-        "name": "api_key"
-      }
-    },
     "schemas": {
       "Body_estimate_fee_estimateFee_post": {
         "properties": {

--- a/ecosystem/rpc/ton-center-http-api-v-3.yaml
+++ b/ecosystem/rpc/ton-center-http-api-v-3.yaml
@@ -449,9 +449,6 @@ paths:
                 $ref: '#/components/schemas/RequestError'
   /api/v3/estimateFee:
     post:
-      security:
-      - APIKeyHeader: []
-      - APIKeyQuery: []
       description: Estimate fees required for query processing. Fields body, init-code
         and init-data accepted in serialized format (b64-encoded).
       tags:
@@ -895,9 +892,6 @@ paths:
                 $ref: '#/components/schemas/RequestError'
   /api/v3/message:
     post:
-      security:
-      - APIKeyHeader: []
-      - APIKeyQuery: []
       description: Send an external message to the TON network.
       tags:
       - api/v2
@@ -1417,9 +1411,6 @@ paths:
                 $ref: '#/components/schemas/RequestError'
   /api/v3/runGetMethod:
     post:
-      security:
-      - APIKeyHeader: []
-      - APIKeyQuery: []
       description: 'Run get method of smart contract. Stack supports only `num`, `cell`
         and `slice` types:
 
@@ -1938,15 +1929,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/RequestError'
 components:
-  securitySchemes:
-    APIKeyHeader:
-      type: apiKey
-      name: X-Api-Key
-      in: header
-    APIKeyQuery:
-      type: apiKey
-      name: api_key
-      in: query
   schemas:
     AccountBalance:
       type: object


### PR DESCRIPTION
Removed all security blocks requiring X-API-Key or api_key query parameter
Updated spec so all endpoints are accessible without authentication