### PR TITLE
fix(internal-infra): skip spellcheck when there are no `.mdx` or `.md` files to check

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           # Preparations
           FILES="$(echo -e "${ALL_CHANGED_FILES[@]}" | tr '\n' ' ')"
-          BODY="{\"body\":\"To fix the **formatting** issues:\n\n1. Install necessary dependencies: \`npm ci\`\n2. Then, run this command:\n\`\`\`shell\nnpx remark -o --quiet --silently-ignore ${FILES}\n\`\`\`\"}"
+          BODY="{\"body\":\"To fix the **formatting** issues:\n\n1. Install necessary dependencies: \`npm ci\`\n2. Then, run this command:\n\`\`\`shell\nnpx remark -o --silent --silently-ignore ${FILES}\n\`\`\`\"}"
           # Comment on the PR
           curl -s -o /dev/null -L -X POST \
             -H "Accept: application/vnd.github+json" \
@@ -79,7 +79,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments
           # Comment right in the actions output
           echo -e "\nInstall necessary dependencies: \033[31mnpm ci\033[0m"
-          echo -e "Then, run this to fix formatting: \033[31mnpx remark -o --quiet --silently-ignore ${FILES}\033[0m"
+          echo -e "Then, run this to fix formatting: \033[31mnpx remark -o --silent --silently-ignore ${FILES}\033[0m"
 
   spell-check:
     name: "Spelling"
@@ -113,6 +113,7 @@ jobs:
 
       - name: Run Vale to spellcheck changed files
         id: check-spell
+        if: steps.changed-files.outputs.all_changed_files != ''
         uses: errata-ai/vale-action@v2.1.1
         with:
           version: "3.12.0"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "check:spell": "vale .",
     "check:spell:compact": "npm run check:spell -- --output line | cut -d ':' -f 5 | sort -h | uniq",
     "check:all": "npm run check:openapi && npm run check:links && npm run check:redirects && npm run check:fs && npm run check:fmt && npm run check:spell",
-    "fmt": "remark . -e mdx,md -o --quiet",
-    "fmt:some": "remark -o --quiet",
+    "fmt": "remark . -e mdx,md -o --silent",
+    "fmt:some": "remark -o --silent",
     "spell": "npm run check:spell",
     "lint:all": "npm run check:all",
     "stats": "python3 scripts/stats.py"


### PR DESCRIPTION
Closes #601. Let's see the fix :)